### PR TITLE
Fix Bash completion if PWD contains whitespace

### DIFF
--- a/dist/osc.complete
+++ b/dist/osc.complete
@@ -87,14 +87,14 @@ lnkprj=""
 lnkpkg=""
 apiurl=""
 alias=""
-test -s ${PWD}/.osc/_project && read -t 1 oscprj < ${PWD}/.osc/_project
-test -s ${PWD}/.osc/_package && read -t 1 oscpkg < ${PWD}/.osc/_package
-if test -s ${PWD}/.osc/_files ; then
-    lnkprj=$(command sed -rn '/<linkinfo/{s@.*[[:blank:]]project="([^"]+)".*@\1@p;}' < ${PWD}/.osc/_files)
-    lnkpkg=$(command sed -rn '/<linkinfo/{s@.*[[:blank:]]package="([^"]+)".*@\1@p;}' < ${PWD}/.osc/_files)
+test -s "${PWD}/.osc/_project" && read -t 1 oscprj < "${PWD}/.osc/_project"
+test -s "${PWD}/.osc/_package" && read -t 1 oscpkg < "${PWD}/.osc/_package"
+if test -s "${PWD}/.osc/_files" ; then
+    lnkprj=$(command sed -rn '/<linkinfo/{s@.*[[:blank:]]project="([^"]+)".*@\1@p;}' < "${PWD}/.osc/_files")
+    lnkpkg=$(command sed -rn '/<linkinfo/{s@.*[[:blank:]]package="([^"]+)".*@\1@p;}' < "${PWD}/.osc/_files")
 fi
-if test -s ${PWD}/.osc/_apiurl -a -s ~/.oscrc ; then
-    read apiurl < ${PWD}/.osc/_apiurl
+if test -s "${PWD}/.osc/_apiurl" -a -s ~/.oscrc ; then
+    read apiurl < "${PWD}/.osc/_apiurl"
     alias=$(sed -rn '\@^\['${apiurl}'@,\@=@{\@^aliases=@{s@[^=]+=([^,]+),.*@\1@p};}' < ~/.oscrc 2> /dev/null)
 fi
 if test "${cmdline[0]}" = isc ; then


### PR DESCRIPTION
The script used ${PWD} without proper quoting causing Bash completion
to not work properly if there was whitespace in the path of the current
working directory.